### PR TITLE
Degrade debian to buster

### DIFF
--- a/Dockerfile-python
+++ b/Dockerfile-python
@@ -2,15 +2,15 @@
 
 # https://hub.docker.com/_/node
 ARG node_version=17.7.2
-FROM node:${node_version}-bullseye-slim as nodejs 
+FROM node:${node_version}-buster-slim as nodejs 
 
 # https://hub.docker.com/r/continuumio/miniconda3
 # https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile
-FROM continuumio/miniconda3:4.10.3p1
+FROM continuumio/miniconda3:4.10.3
 
 LABEL maintainer="HeRoMo"
 LABEL Description="Jupyter lab for Python3 and Javascript"
-LABEL Version="5.15.0"
+LABEL Version="5.15.1"
 
 ENV HOME=/root
 ENV NOTEBOOK_DIR=/jupyter/notebooks


### PR DESCRIPTION
Because latest Erlang and Elixir don't support Bullseye